### PR TITLE
Add Google Analytics gtag snippet to site HTML pages

### DIFF
--- a/chinese-time.html
+++ b/chinese-time.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chinese Almanac - Countdown Website</title>

--- a/christmas.html
+++ b/christmas.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="圣诞节倒计时器 - 免费在线圣诞节倒计时，精确到秒的圣诞倒计时显示。温馨的圣诞节氛围，感受节日的欢乐。支持圣诞节倒计时分享和嵌入。">

--- a/embed-generator.html
+++ b/embed-generator.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="倒计时器嵌入代码生成器 - 免费生成倒计时器嵌入代码，支持自定义倒计时、在线计时器嵌入。轻松将倒计时器嵌入到您的网站或博客中。">

--- a/embed.html
+++ b/embed.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>倒计时计时器 - 嵌入版</title>

--- a/game.html
+++ b/game.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>倒计时小游戏 - 倒计时网站</title>

--- a/halloween.html
+++ b/halloween.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>万圣节倒计时 - 倒计时网站</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
 <script src="https://fpyf8.com/88/tag.min.js" data-zone="174776" async data-cfasync="false"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/newyear.html
+++ b/newyear.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1DJ55QWP9E"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1DJ55QWP9E');
+</script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="新年倒计时器 - 免费在线新年倒计时，精确到秒的跨年倒计时显示。激动人心的新年倒计时时刻，迎接新年的到来。支持新年倒计时分享和嵌入。">


### PR DESCRIPTION
### Motivation
- Add the provided Google Analytics `gtag.js` snippet to each site HTML page so page views are tracked using property `G-1DJ55QWP9E`.
- Insert the snippet directly after the `<head>` tag (not using Google Tag Manager) to ensure a single analytics snippet per page.
- Apply the change consistently across the static HTML site so embedded/iframe pages are also tracked.

### Description
- Inserted the `<!-- Google tag (gtag.js) -->` snippet (with ID `G-1DJ55QWP9E`) immediately after the `<head>` tag in site HTML files.
- Updated the following files: `index.html`, `chinese-time.html`, `christmas.html`, `embed-generator.html`, `embed.html`, `game.html`, `halloween.html`, and `newyear.html`.
- Used a small Python script to perform the insertion and skip files that already contained the tracking ID, then staged and committed the changes.

### Testing
- Ran the Python insertion script to add the snippet to all `*.html` files and it completed successfully.
- Verified presence of the snippet in several files using `sed` checks which showed the snippet at the top of the `<head>` section.
- Confirmed modified files with `git status` and successfully committed the changes with `git commit`.
- No runtime or browser analytics validation was executed (static HTML changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a53901fb88321852276877269a670)